### PR TITLE
Change to target frameworks and add dotnet core 3.1

### DIFF
--- a/.github/workflows/dotnetTest.yml
+++ b/.github/workflows/dotnetTest.yml
@@ -11,7 +11,7 @@ jobs:
     name: Dotnet v${{ matrix.dotnet }} on ${{ matrix.os }} for ${{ matrix.dir }} directory
     strategy:
         matrix:
-          dotnet: [ '5.0.x' ]
+          dotnet: [ '5.0.x', '3.1.x' ]
           os: [ ubuntu-latest, windows-latest ]
           dir: [ console ]
     defaults:

--- a/console/console.csproj
+++ b/console/console.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
-
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR fixes #16 

- [x] Add .Net core v3.1 as a target framework
- [x] Update github actions to also test for the new version